### PR TITLE
feat: add LookupsV2 Support line_type_intelligence

### DIFF
--- a/lib/mock/twilio/decorator.rb
+++ b/lib/mock/twilio/decorator.rb
@@ -5,6 +5,7 @@ require_relative "schemas/messaging_v1"
 require_relative "schemas/customer_profiles_v1"
 require_relative "schemas/end_users_v1"
 require_relative "schemas/supporting_documents_v1"
+require_relative "schemas/phone_numbers_v2"
 
 module Mock
   module Twilio
@@ -14,7 +15,8 @@ module Mock
         messaging_v1: Mock::Twilio::Schemas::MessagingV1,
         customer_profiles_v1: Mock::Twilio::Schemas::CustomerProfilesV1,
         end_users_v1: Mock::Twilio::Schemas::EndUsersV1,
-        supporting_documents_v1: Mock::Twilio::Schemas::SupportingDocumentsV1
+        supporting_documents_v1: Mock::Twilio::Schemas::SupportingDocumentsV1,
+        phone_numbers_v2: Mock::Twilio::Schemas::PhoneNumbersV2
       }
 
       class << self
@@ -47,6 +49,8 @@ module Mock
             :end_users_v1
           when %r{\/v1/SupportingDocuments}
             :supporting_documents_v1
+          when %r{\/v2/PhoneNumbers}
+            :phone_numbers_v2
           end
         end
       end

--- a/lib/mock/twilio/schemas/phone_numbers_v2.rb
+++ b/lib/mock/twilio/schemas/phone_numbers_v2.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Mock
+  module Twilio
+    module Schemas
+      class PhoneNumbersV2
+        class << self
+          def for(body, request)
+            body["calling_country_code"] = '1' if body["calling_country_code"]
+            body["country_code"] = 'US' if body["country_code"]
+            body["valid"] = true if body["valid"]
+            body["validation_errors"] = [] if body["validation_errors"]
+            body["line_type_intelligence"] = { "carrier_name" => "Mock::Twilio - SMS/MMS-SVR", "type" => "mock" }
+
+            body
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/mock/test_mock_lookups.rb
+++ b/test/mock/test_mock_lookups.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Mock::TestTwilio < Minitest::Test
+  def test_mock_client_lookups_v2
+    mock_server_response = { "calling_country_code"=>"1",
+                             "country_code"=>"US",
+                             "phone_number"=>"string",
+                             "national_format"=>"string",
+                             "valid"=>true,
+                             "validation_errors"=>[],
+                             "caller_name"=>nil,
+                             "sim_swap"=>nil,
+                             "call_forwarding"=>nil,
+                             "line_status"=>nil,
+                             "line_type_intelligence"=>nil,
+                             "identity_match"=>nil,
+                             "reassigned_number"=>nil,
+                             "sms_pumping_risk"=>nil,
+                             "phone_number_quality_score"=>nil,
+                             "pre_fill"=>nil,
+                             "url"=>"http://example.com"}
+
+    stub_request(:get, "http://twilio_mock_server:4010/v2/PhoneNumbers/+1123456789?Fields=line_type_intelligence").
+      with(
+        headers: {
+          'Accept'=>'application/json',
+          'Accept-Charset'=>'utf-8',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
+          'User-Agent'=>'twilio-ruby/6.7.1 (linux x86_64) Ruby/3.2.2'
+        }).
+        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+
+    mock_client = Mock::Twilio::Client.new
+    client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
+    response = client.lookups.v2.phone_numbers("+1123456789") .fetch(fields: :line_type_intelligence)
+
+    assert_equal "mock", response.line_type_intelligence["type"]
+    assert response.valid
+  end
+end


### PR DESCRIPTION
### Support LookupsV2 
## line_type_intelligence
```ruby
client.lookups.v2.phone_numbers("+1123456789") .fetch(fields: :line_type_intelligence)
```

![image](https://github.com/schoolstatus/mock-twilio/assets/1800826/2cb4c4bf-66e9-41e0-b97f-48b6a1d5063d)
