### PR TITLE
feat: Override Twilio Messaging PhoneNumberList Limit

### DIFF
--- a/lib/mock/twilio.rb
+++ b/lib/mock/twilio.rb
@@ -3,6 +3,7 @@
 require "rufus-scheduler"
 require "active_support"
 require "active_support/core_ext/time"
+require "twilio-ruby"
 require_relative "twilio/middleware/proxy"
 require_relative "twilio/webhook_client"
 require_relative "twilio/webhooks/base"
@@ -16,6 +17,7 @@ require_relative "twilio/client"
 require_relative "twilio/decorator"
 require_relative "twilio/response"
 require_relative "twilio/version"
+require_relative "../twilio/rest/messaging/v1/service/phone_number_decorator"
 
 module Mock
   module Twilio

--- a/lib/twilio/rest/messaging/v1/service/phone_number_decorator.rb
+++ b/lib/twilio/rest/messaging/v1/service/phone_number_decorator.rb
@@ -1,0 +1,8 @@
+Twilio::REST::Messaging::V1::ServiceContext::PhoneNumberList.class_eval do
+  def list(limit: nil, page_size: nil)
+    self.stream(
+      limit: 1,
+      page_size: page_size
+    ).entries
+  end
+end


### PR DESCRIPTION
Because Twilio Default is no limit it can perform as many requests per limit raising Time outs on higher limit values,
so it must be limit: 1 for mocking.

https://github.com/twilio/twilio-ruby/blob/main/lib/twilio-ruby/rest/messaging/v1/service/phone_number.rb#L69