### PR TITLE
feat: Add conference call no-answer use case webhooks flow

### DIFF
--- a/lib/mock/twilio/webhooks/call_status_updates.rb
+++ b/lib/mock/twilio/webhooks/call_status_updates.rb
@@ -6,13 +6,13 @@ module Mock
       class CallStatusUpdates < Base
         URL = "/api/v1/twilio_calls/voice_responses"
 
-        def self.trigger(sid, conference_uuid)
+        def self.trigger(sid, conference_uuid, answered_by)
           # Wait simulation from twilio
           sleep DELAY.sample
 
           request_url = Mock::Twilio.proto + "://" + Mock::Twilio.forwarded_host + URL
 
-          data = call_status_updates_data(sid, conference_uuid)
+          data = call_status_updates_data(sid, conference_uuid, answered_by)
 
           signature = build_signature_for_request(request_url, data)
 
@@ -33,7 +33,7 @@ module Mock
           end
         end
 
-        def self.call_status_updates_data(sid, conference_uuid)
+        def self.call_status_updates_data(sid, conference_uuid, answered_by)
           {
             :AccountSid=> twilio_client.account_sid,
             :ApiVersion=>	"2010-04-01",
@@ -68,7 +68,7 @@ module Mock
             :ToZip=> "33605",
             :StirStatus=> "B",
             :StirVerstat=> "TN-Validation-Passed-B",
-            :AnsweredBy=> "unknown",
+            :AnsweredBy=> answered_by,
             :conference_uuid=> conference_uuid
           }
         end

--- a/lib/mock/twilio/webhooks/calls.rb
+++ b/lib/mock/twilio/webhooks/calls.rb
@@ -50,7 +50,7 @@ module Mock
             :CallerState=> "CA",
             :CallerZip=> "no value",
             :CallSid=> sid,
-            :CallStatus=> "in-progress",
+            :CallStatus=> "ringing",
             :Direction=> "outbound-api",
             :Duration=> "0",
             :From=>	"+18111111111",

--- a/test/mock/test_mock_webhooks.rb
+++ b/test/mock/test_mock_webhooks.rb
@@ -76,7 +76,7 @@ class Mock::TestTwilio < Minitest::Test
   def test_mock_webhook_calls_trigger
     stub_request(:post, "http://shunkan-ido-service:3000/api/v1/twilio_calls/participant_status_changes").
       with(
-        body: {"AccountSid"=>"ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "ApiVersion"=>"2010-04-01", "CallDuration"=>"0", "CallSid"=>"SIDTESTING", "CallStatus"=>"in-progress", "CallbackSource"=>"call-progress-events", "Called"=>"+18222222222", "CalledCity"=>"TAMPA", "CalledCountry"=>"US", "CalledState"=>"FL", "CalledZip"=>"33605", "Caller"=>"+18111111111", "CallerCity"=>"no value", "CallerCountry"=>"US", "CallerState"=>"CA", "CallerZip"=>"no value", "Direction"=>"outbound-api", "Duration"=>"0", "From"=>"+18111111111", "FromCity"=>"no value", "FromCountry"=>"US", "FromState"=>"CA", "FromZip"=>"no value", "SequenceNumber"=>"2", "SipResponseCode"=>"487", "Timestamp"=>"2024-06-17 16:49:31 UTC", "To"=>"+18222222222", "ToCity"=>"TAMPA", "ToCountry"=>"US", "ToState"=>"FL", "ToZip"=>"33605"},
+        body: {"AccountSid"=>"ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "ApiVersion"=>"2010-04-01", "CallDuration"=>"0", "CallSid"=>"SIDTESTING", "CallStatus"=>"ringing", "CallbackSource"=>"call-progress-events", "Called"=>"+18222222222", "CalledCity"=>"TAMPA", "CalledCountry"=>"US", "CalledState"=>"FL", "CalledZip"=>"33605", "Caller"=>"+18111111111", "CallerCity"=>"no value", "CallerCountry"=>"US", "CallerState"=>"CA", "CallerZip"=>"no value", "Direction"=>"outbound-api", "Duration"=>"0", "From"=>"+18111111111", "FromCity"=>"no value", "FromCountry"=>"US", "FromState"=>"CA", "FromZip"=>"no value", "SequenceNumber"=>"2", "SipResponseCode"=>"487", "Timestamp"=>"2024-06-17 16:49:31 UTC", "To"=>"+18222222222", "ToCity"=>"TAMPA", "ToCountry"=>"US", "ToState"=>"FL", "ToZip"=>"33605"},
         headers: {
           'Accept'=>'*/*',
           'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
@@ -85,7 +85,7 @@ class Mock::TestTwilio < Minitest::Test
           'Host'=>'forwarded_host.app',
           'User-Agent'=>'Faraday v2.9.1',
           'X-Forwarded-Proto'=>'http',
-          'X-Twilio-Signature'=>'WxOk5XXhmUhA+ZcHe9XDfqn64cM='
+          'X-Twilio-Signature'=>'qkaaZdYzQG1Bt9X9dEghrNI/DnY='
         }).
         to_return(status: 200, body: "", headers: {})
 
@@ -93,8 +93,8 @@ class Mock::TestTwilio < Minitest::Test
 
     assert_equal "forwarded_host.app", response.env.request_headers['Host']
     assert_equal "http", response.env.request_headers['X-forwarded-proto']
-    assert_equal "WxOk5XXhmUhA+ZcHe9XDfqn64cM=", response.env.request_headers['X-twilio-signature']
-    assert response.env.request_body.include?("in-progress")
+    assert_equal "qkaaZdYzQG1Bt9X9dEghrNI/DnY=", response.env.request_headers['X-twilio-signature']
+    assert response.env.request_body.include?("ringing")
   end
 
   def test_mock_webhook_calls_updates_trigger
@@ -113,7 +113,7 @@ class Mock::TestTwilio < Minitest::Test
         }).
         to_return(status: 200, body: "", headers: {})
 
-    response = Mock::Twilio::Webhooks::CallStatusUpdates.trigger("SIDTESTING","123abc")
+    response = Mock::Twilio::Webhooks::CallStatusUpdates.trigger("SIDTESTING","123abc", "unknown")
 
     assert_equal "forwarded_host.app", response.env.request_headers['Host']
     assert_equal "http", response.env.request_headers['X-forwarded-proto']


### PR DESCRIPTION
## Conference call `no-answer` use case flow webhooks
- ringing
![image](https://github.com/user-attachments/assets/d71569a9-1f4e-4547-b32b-185bd15c1e56)
- no-answer
![image](https://github.com/user-attachments/assets/7da80577-3583-45c0-8cb2-cc75f4b64bf1)
