### PR TITLE
COMM-838 trust product/customer profile channel endpoint assignments …

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,16 @@ OR
 | :white_check_mark: | `client.messaging.v1.services("MG"+"F"*32).phone_numbers.create(phone_number_sid: @phone_number_sid)`  |
 | :white_check_mark: | `client.available_phone_numbers('US').local.list(limit: 20)`  |
 | :white_check_mark: | `client.incoming_phone_numbers.create(phone_number: "+1987654321", voice_url: "#{BASE_URL}/api/v1/twilio_calls/incoming", sms_url: "#{BASE_URL}/api/v1/twilio_requests/inbound")`  |
+| :white_check_mark: | `client.incoming_phone_numbers.update(sms_application_sid: "AP"+"F"*32, voice_application_sid: "AP"+"F"*32)`  |
 | :white_check_mark: | `client.lookups.v2.phone_numbers("+14159929960").fetch(fields: :line_type_intelligence)`  |
 | :white_check_mark: | `client.calls.create(url: '<http://demo.twilio.com/docs/voice.xml>', to: '+14155551212', from: '+15017122661', status_callback: '<https://myapp.com/events>', status_callback_event: ['ringing'], status_callback_method: 'POST')`  |
 | :white_check_mark: | `client.conferences("CF"+("F")*32).participants.create(label: 'customer', early_media: true, beep: 'onEnter', status_callback: '<https://myapp.com/events>', status_callback_event: ['ringing'], record: true, from: '+15017122661', to: '+15558675310')`  |
 | :white_check_mark: | `client.trusthub.v1.customer_profiles.create(**twilio_attributes)`  |
 | :white_check_mark: | `client.trusthub.v1.customer_profiles(customer_profile_sid).customer_profiles_entity_assignments.create(object_sid:)`  |
+| :white_check_mark: | `client.trusthub.v1.customer_profiles("BU"+"F"*32).customer_profiles_channel_endpoint_assignment.list(limit: 20)`  |
+| :white_check_mark: | `client.trusthub.v1.customer_profiles("BU"+"F"*32).customer_profiles_channel_endpoint_assignment("RA"+"F"*32).delete`  |
+| :white_check_mark: | `client.trusthub.v1.trust_products("BU"+"F"*32).trust_products_channel_endpoint_assignment.list(limit: 20)`  |
+| :white_check_mark: | `client.trusthub.v1.trust_products("BU"+"F"*32).trust_products_channel_endpoint_assignment("RA"+"F"*32).delete`  |
 | :white_check_mark: | `client.trusthub.v1.end_users.create(**twilio_parameters)`
 | :white_check_mark: | `client.trusthub.v1.supporting_documents.create(**twilio_parameters)`  |
 | :white_check_mark: | `client.addresses.create(**twilio_parameters)`  |

--- a/lib/mock/twilio/decorators/api_2010/incoming_phone_numbers.rb
+++ b/lib/mock/twilio/decorators/api_2010/incoming_phone_numbers.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Mock
+  module Twilio
+    module Decorators
+      module Api2010
+        class IncomingPhoneNumbers
+          class << self
+            include Mock::Twilio::Generator
+
+            def decorate(body, request)
+              body["date_updated"] = Time.current.rfc2822 if body["date_updated"]
+              body["date_created"] = Time.current.rfc2822 if body["date_created"]
+              body["account_sid"] = ::Twilio.account_sid if body["account_sid"]
+
+              body["sid"] = random_phone_number_sid if body["sid"]
+              body["identity_sid"] = random_identity_sid if body["identity_sid"]
+              body["emergency_address_sid"] = random_address_sid if body["emergency_address_sid"]
+              body["address_sid"] = random_address_sid if body["address_sid"]
+              body["bundle_sid"] = random_bundle_sid if body["bundle_sid"]
+
+              body
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mock/twilio/decorators/customer_profiles_v1/channel_endpoint_assignments.rb
+++ b/lib/mock/twilio/decorators/customer_profiles_v1/channel_endpoint_assignments.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Mock
+  module Twilio
+    module Decorators
+      module CustomerProfilesV1
+        class ChannelEndpointAssignments
+          class << self
+            include Mock::Twilio::Generator
+
+            def decorate(body, request)
+              decorate_results(body, request) unless body["results"].nil?
+              decorate_meta(body, request) unless body["meta"].nil?
+
+              body
+            end
+
+            private
+
+            def decorate_meta(body, request)
+              customer_profile_sid = parse_customer_profile_sid(request)
+
+              body["meta"].tap do |meta|
+                page_size = body["results"].length
+                meta["page_size"] = page_size
+                meta["first_page_url"] = "https://trusthub.twilio.com/v1/CustomerProfiles#{customer_profile_sid}/ChannelEndpointAssignments?PageSize=#{page_size}&Page=0"
+                meta["previous_page_url"] = nil
+                meta["next_page_url"] = nil
+                meta["url"] = "https://trusthub.twilio.com/v1/CustomerProfiles#{customer_profile_sid}/ChannelEndpointAssignments?PageSize=#{page_size}&Page=0"
+                meta["key"] = "results"
+              end
+            end
+
+            def decorate_results(body, request)
+              customer_profile_sid = parse_customer_profile_sid(request)
+
+              body["results"].each do |result|
+                result["customer_profile_sid"] = customer_profile_sid if result["customer_profile_sid"]
+                result["sid"] = random_assignment_sid if result["sid"]
+                result["channel_endpoint_sid"] = random_phone_number_sid if result["channel_endpoint_sid"]
+                result["url"] = "https://trusthub.twilio.com/v1/CustomerProfiles/#{customer_profile_sid}/ChannelEndpointAssignments/#{result["sid"]}"
+                result["channel_endpoint_type"] = "phone-number" if result["channel_endpoint_type"]
+                result["account_sid"] = ::Twilio.account_sid
+                result["date_created"] = Time.current.rfc2822 if result["date_created"]
+              end
+            end
+
+            def parse_customer_profile_sid(request)
+              uri = URI(request.url)
+              uri.path.split('/')[3]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mock/twilio/decorators/trust_products_v1/channel_endpoint_assignments.rb
+++ b/lib/mock/twilio/decorators/trust_products_v1/channel_endpoint_assignments.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Mock
+  module Twilio
+    module Decorators
+      module TrustProductsV1
+        class ChannelEndpointAssignments
+          class << self
+            include Mock::Twilio::Generator
+
+            def decorate(body, request)
+              decorate_results(body, request) unless body["results"].nil?
+              decorate_meta(body, request) unless body["meta"].nil?
+
+              body
+            end
+
+            private
+
+            def decorate_meta(body, request)
+              trust_product_sid = parse_trust_product_sid(request)
+
+              body["meta"].tap do |meta|
+                page_size = body["results"].length
+                meta["page_size"] = page_size
+                meta["first_page_url"] = "https://trusthub.twilio.com/v1/TrustProducts/#{trust_product_sid}/ChannelEndpointAssignments?PageSize=#{page_size}&Page=0"
+                meta["previous_page_url"] = nil
+                meta["next_page_url"] = nil
+                meta["url"] = "https://trusthub.twilio.com/v1/TrustProducts/#{trust_product_sid}/ChannelEndpointAssignments?PageSize=#{page_size}&Page=0"
+                meta["key"] = "results"
+              end
+            end
+
+            def decorate_results(body, request)
+              trust_product_sid = parse_trust_product_sid(request)
+
+              body["results"].each do |result|
+                result["trust_product_sid"] = trust_product_sid if result["trust_product_sid"]
+                result["sid"] = random_assignment_sid if result["sid"]
+                result["channel_endpoint_sid"] = random_phone_number_sid if result["channel_endpoint_sid"]
+                result["url"] = "https://trusthub.twilio.com/v1/TrustProducts/#{trust_product_sid}/ChannelEndpointAssignments/#{result["sid"]}"
+                result["channel_endpoint_type"] = "phone-number" if result["channel_endpoint_type"]
+                result["account_sid"] = ::Twilio.account_sid
+                result["date_created"] = Time.current.rfc2822 if result["date_created"]
+              end
+            end
+
+            def parse_trust_product_sid(request)
+              uri = URI(request.url)
+              uri.path.split('/')[3]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mock/twilio/schemas/api_2010.rb
+++ b/lib/mock/twilio/schemas/api_2010.rb
@@ -5,6 +5,7 @@ require_relative "../decorators/api_2010/calls"
 require_relative "../decorators/api_2010/conferences_participants_update"
 require_relative "../decorators/api_2010/conferences_participants_create"
 require_relative "../decorators/api_2010/addresses"
+require_relative "../decorators/api_2010/incoming_phone_numbers"
 
 module Mock
   module Twilio
@@ -17,6 +18,7 @@ module Mock
             conferences_participants_update: Mock::Twilio::Decorators::Api2010::ConferencesParticipantsUpdate,
             conferences_participants_create: Mock::Twilio::Decorators::Api2010::ConferencesParticipantsCreate,
             addresses: Mock::Twilio::Decorators::Api2010::Addresses,
+            incoming_phone_numbers: Mock::Twilio::Decorators::Api2010::IncomingPhoneNumbers,
           }
 
           PAGES_KEYS = [
@@ -47,6 +49,8 @@ module Mock
               RESOURCES[:conferences_participants_create].decorate(body, request)
             when %r{\/2010-04-01/Accounts/[A-Za-z0-9]+/Addresses.json}
               RESOURCES[:addresses].decorate(body, request)
+            when %r{\/2010-04-01/Accounts/[A-Za-z0-9]+/IncomingPhoneNumbers/[A-Za-z0-9]+.json}
+              RESOURCES[:incoming_phone_numbers].decorate(body, request)
             end
           end
         end

--- a/lib/mock/twilio/schemas/customer_profiles_v1.rb
+++ b/lib/mock/twilio/schemas/customer_profiles_v1.rb
@@ -4,6 +4,7 @@ require_relative "../decorators/customer_profiles_v1/customer_profile"
 require_relative "../decorators/customer_profiles_v1/entity_assignments"
 require_relative "../decorators/customer_profiles_v1/evaluations"
 require_relative "../decorators/customer_profiles_v1/customer_profile_update"
+require_relative "../decorators/customer_profiles_v1/channel_endpoint_assignments"
 
 module Mock
   module Twilio
@@ -15,19 +16,26 @@ module Mock
             entity_assigments: Mock::Twilio::Decorators::CustomerProfilesV1::EntityAssignments,
             evaluations: Mock::Twilio::Decorators::CustomerProfilesV1::Evaluations,
             customer_profile_update: Mock::Twilio::Decorators::CustomerProfilesV1::CustomerProfileUpdate,
+            channel_endpoint_assignments: Mock::Twilio::Decorators::CustomerProfilesV1::ChannelEndpointAssignments,
           }
 
           def for(body, request)
             url = request.url.split(request.host).last
 
             case url
-            when %r{\/v1/CustomerProfiles$}
+            when %r{/v1/CustomerProfiles$}
               RESOURCES[:customer_profile].decorate(body, request)
-            when %r{\/v1/CustomerProfiles/[A-Za-z0-9]+/EntityAssignments}
+            when %r{/v1/CustomerProfiles/[A-Za-z0-9]+/EntityAssignments}
               RESOURCES[:entity_assigments].decorate(body, request)
-            when %r{\/v1/CustomerProfiles/[A-Za-z0-9]+/Evaluations}
+            when %r{/v1/CustomerProfiles/[A-Za-z0-9]+/Evaluations}
               RESOURCES[:evaluations].decorate(body, request)
-            when %r{\/v1/CustomerProfiles/[A-Za-z0-0]+}
+            when %r{/v1/CustomerProfiles/[A-Za-z0-9]+/ChannelEndpointAssignments}
+              if request.method.downcase == 'get'
+                RESOURCES[:channel_endpoint_assignments].decorate(body, request)
+              else
+                body
+              end
+            when %r{/v1/CustomerProfiles/[A-Za-z0-0]+}
               RESOURCES[:customer_profile_update].decorate(body, request)
             end
           end

--- a/lib/mock/twilio/schemas/trust_products_v1.rb
+++ b/lib/mock/twilio/schemas/trust_products_v1.rb
@@ -4,6 +4,7 @@ require_relative "../decorators/trust_products_v1/trust_products"
 require_relative "../decorators/trust_products_v1/update"
 require_relative "../decorators/trust_products_v1/evaluations"
 require_relative "../decorators/trust_products_v1/entity_assignments"
+require_relative "../decorators/trust_products_v1/channel_endpoint_assignments"
 
 module Mock
   module Twilio
@@ -15,20 +16,27 @@ module Mock
             update: Mock::Twilio::Decorators::TrustProductsV1::Update,
             evaluations: Mock::Twilio::Decorators::TrustProductsV1::Evaluations,
             entity_assignments: Mock::Twilio::Decorators::TrustProductsV1::EntityAssignments,
+            channel_endpoint_assignments: Mock::Twilio::Decorators::TrustProductsV1::ChannelEndpointAssignments,
           }
 
           def for(body, request)
             url = request.url.split(request.host).last
 
             case url
-            when %r{\/v1/TrustProducts$}
+            when %r{/v1/TrustProducts$}
               RESOURCES[:trust_products].decorate(body, request)
-            when %r{\/v1/TrustProducts/\w{34}$}
+            when %r{/v1/TrustProducts/\w{34}$}
               RESOURCES[:update].decorate(body, request)
-            when %r{\/v1\/TrustProducts\/\w{34}\/Evaluations$}
+            when %r{/v1/TrustProducts/\w{34}/Evaluations$}
               RESOURCES[:evaluations].decorate(body, request)
-            when %r{\/v1\/TrustProducts\/\w{34}\/EntityAssignments$}
+            when %r{/v1/TrustProducts/\w{34}/EntityAssignments$}
               RESOURCES[:entity_assignments].decorate(body, request)
+            when %r{/v1/TrustProducts/[A-Za-z0-9]+/ChannelEndpointAssignments}
+              if request.method.downcase == 'get'
+                RESOURCES[:channel_endpoint_assignments].decorate(body, request)
+              else
+                body
+              end
             end
           end
         end

--- a/lib/mock/twilio/util/generator.rb
+++ b/lib/mock/twilio/util/generator.rb
@@ -6,6 +6,40 @@ module Mock
       def phone_number_generator
         "+1" + rand(100000000..999999999).to_s
       end
+
+      def random_phone_number_sid
+        random_sid_prefixed_by "PN"
+      end
+
+      def random_account_sid
+        random_sid_prefixed_by "AC"
+      end
+
+      def random_twiml_app_sid
+        random_sid_prefixed_by "AP"
+      end
+
+      def random_identity_sid
+        random_sid_prefixed_by "RI"
+      end
+
+      def random_address_sid
+        random_sid_prefixed_by "AD"
+      end
+
+      def random_bundle_sid
+        random_sid_prefixed_by "BU"
+      end
+
+      def random_assignment_sid
+        random_sid_prefixed_by "RA"
+      end
+
+      private
+
+      def random_sid_prefixed_by(prefix)
+        "#{prefix}#{SecureRandom.hex(16)}"
+      end
     end
   end
 end

--- a/test/mock/test_mock_addresses.rb
+++ b/test/mock/test_mock_addresses.rb
@@ -22,17 +22,8 @@ class Mock::TestTwilio < Minitest::Test
                              "street_secondary"=>"string"}
 
     stub_request(:post, "http://twilio_mock_server:4010/2010-04-01/Accounts/ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/Addresses.json").
-      with(
-        body: {"City"=>"city", "CustomerName"=>"customer_name", "FriendlyName"=>"friendly_name", "IsoCountry"=>"iso_country", "PostalCode"=>"postal_code", "Region"=>"region", "Street"=>"street", "StreetSecondary"=>"street_secondary"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"City"=>"city", "CustomerName"=>"customer_name", "FriendlyName"=>"friendly_name", "IsoCountry"=>"iso_country", "PostalCode"=>"postal_code", "Region"=>"region", "Street"=>"street", "StreetSecondary"=>"street_secondary"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
     payload = {
       friendly_name: "friendly_name",

--- a/test/mock/test_mock_brands.rb
+++ b/test/mock/test_mock_brands.rb
@@ -28,17 +28,8 @@ class Mock::TestTwilio < Minitest::Test
                              "links"=>{}}
 
     stub_request(:post, "http://twilio_mock_server:4010/v1/a2p/BrandRegistrations").
-      with(
-        body: {"A2PProfileBundleSid"=>"BUFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "BrandType"=>"STANDARD", "CustomerProfileBundleSid"=>"BUFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "Mock"=>"true"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"A2PProfileBundleSid"=>"BUFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "BrandType"=>"STANDARD", "CustomerProfileBundleSid"=>"BUFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "Mock"=>"true"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
 
     twilio_params = { customer_profile_bundle_sid: "BUFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",

--- a/test/mock/test_mock_calls.rb
+++ b/test/mock/test_mock_calls.rb
@@ -36,17 +36,8 @@ class Mock::TestTwilio < Minitest::Test
                              "subresource_uris"=>{}}
 
     stub_request(:post, "http://twilio_mock_server:4010/2010-04-01/Accounts/ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/Calls.json").
-      with(
-        body: {"From"=>"+18111111111", "MachineDetection"=>"Enable", "StatusCallback"=>"http://shunkan-ido-service/api/v1/twilio_calls/participant_status_changes", "StatusCallbackEvent"=>"completed", "StatusCallbackMethod"=>"POST", "Timeout"=>"30", "To"=>"+18222222222", "Url"=>"http://shunkan-ido-service/api/v1/twilio_calls/voice_responses?conference_uuid=c843e10f-142a-4c31-a1ca-dcf67233c7c8"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"From"=>"+18111111111", "MachineDetection"=>"Enable", "StatusCallback"=>"http://shunkan-ido-service/api/v1/twilio_calls/participant_status_changes", "StatusCallbackEvent"=>"completed", "StatusCallbackMethod"=>"POST", "Timeout"=>"30", "To"=>"+18222222222", "Url"=>"http://shunkan-ido-service/api/v1/twilio_calls/voice_responses?conference_uuid=c843e10f-142a-4c31-a1ca-dcf67233c7c8"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
     conference_uuid = "c843e10f-142a-4c31-a1ca-dcf67233c7c8"
     twilio_number = "+18111111111"

--- a/test/mock/test_mock_conferences.rb
+++ b/test/mock/test_mock_conferences.rb
@@ -24,17 +24,8 @@ class Mock::TestTwilio < Minitest::Test
                              "uri"=>"string"}
 
     stub_request(:post, "http://twilio_mock_server:4010/2010-04-01/Accounts/ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/Conferences/CF5bb996a0f3deaa0c6bb1b17ffd338c87/Participants.json").
-      with(
-        body: {"Beep"=>"onEnter", "EarlyMedia"=>"true", "From"=>"+18111111111", "Record"=>"true", "StatusCallback"=>"http://shunkan-ido-service/api/v1/twilio_calls/participant_status_changes", "StatusCallbackEvent"=>"completed", "Timeout"=>"30", "To"=>"+18222222222"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"Beep"=>"onEnter", "EarlyMedia"=>"true", "From"=>"+18111111111", "Record"=>"true", "StatusCallback"=>"http://shunkan-ido-service/api/v1/twilio_calls/participant_status_changes", "StatusCallbackEvent"=>"completed", "Timeout"=>"30", "To"=>"+18222222222"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
 
     conference_sid = "CF5bb996a0f3deaa0c6bb1b17ffd338c87"
@@ -81,17 +72,8 @@ class Mock::TestTwilio < Minitest::Test
                             "uri"=>"string" }
 
     stub_request(:post, "http://twilio_mock_server:4010/2010-04-01/Accounts/ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/Conferences/CF5bb996a0f3deaa0c6bb1b17ffd338c87/Participants/CA06f6360ddeb85932241e0be5407d4f7d.json").
-      with(
-        body: {"AnnounceMethod"=>"GET", "AnnounceUrl"=>"http://shunkan-ido-service/api/v1/twilio_calls/123abc/call_welcome_message"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"AnnounceMethod"=>"GET", "AnnounceUrl"=>"http://shunkan-ido-service/api/v1/twilio_calls/123abc/call_welcome_message"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
     payload = {
       announce_method: "GET",

--- a/test/mock/test_mock_customer_profiles.rb
+++ b/test/mock/test_mock_customer_profiles.rb
@@ -20,17 +20,8 @@ class Mock::TestTwilio < Minitest::Test
                               "links"=>{}}
 
     stub_request(:post, "http://twilio_mock_server:4010/v1/CustomerProfiles").
-      with(
-        body: {"Email"=>"test@test.com", "FriendlyName"=>"Test friendly_name", "PolicySid"=>"RNFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "StatusCallback"=>"http://host.com/webhooks/twilio/customer_profiles_compliance"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"Email"=>"test@test.com", "FriendlyName"=>"Test friendly_name", "PolicySid"=>"RNFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "StatusCallback"=>"http://host.com/webhooks/twilio/customer_profiles_compliance"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
 
     twilio_attributes = {
@@ -61,17 +52,8 @@ class Mock::TestTwilio < Minitest::Test
                               "url"=>"http://example.com"}
 
     stub_request(:post, "http://twilio_mock_server:4010/v1/CustomerProfiles/BUFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/EntityAssignments").
-      with(
-        body: {"ObjectSid"=>"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"ObjectSid"=>"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
     mock_client = Mock::Twilio::Client.new
     client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
@@ -93,17 +75,8 @@ class Mock::TestTwilio < Minitest::Test
                              "url"=>"http://example.com"}
 
     stub_request(:post, "http://twilio_mock_server:4010/v1/CustomerProfiles/BUaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Evaluations").
-      with(
-        body: {"PolicySid"=>"RNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"PolicySid"=>"RNaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
 
     mock_client = Mock::Twilio::Client.new
@@ -130,17 +103,8 @@ class Mock::TestTwilio < Minitest::Test
                              "links"=>{}}
 
     stub_request(:post, "http://twilio_mock_server:4010/v1/CustomerProfiles/BU8f9119bc8f39527dacf01b65b9acb329").
-      with(
-        body: {"Status"=>"pending-review"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"Status"=>"pending-review"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
 
     mock_client = Mock::Twilio::Client.new
@@ -149,5 +113,48 @@ class Mock::TestTwilio < Minitest::Test
 
     assert_equal "BU", response.sid[0,2]
     assert_equal "pending-review", response.status
+  end
+
+  def test_mock_client_customer_profiles_channel_endpoint_assignments
+    mock_server_response = {
+      "results" => [
+        {
+          "sid" => "stringstringstringstringstringstri",
+          "customer_profile_sid" => "stringstringstringstringstringstri",
+          "account_sid" => "stringstringstringstringstringstri",
+          "channel_endpoint_type" => "string",
+          "channel_endpoint_sid" => "stringstringstringstringstringstri",
+          "date_created" => "2019-08-24T14:15:22Z",
+          "url" => "http://example.com"
+        }
+      ],
+      "meta" => {
+        "first_page_url" => "http://example.com",
+        "next_page_url" => "http://example.com",
+        "page" => 0,
+        "page_size" => 0,
+        "previous_page_url" => "http://example.com",
+        "url" => "http://example.com",
+        "key" => "string"
+      }
+    }
+
+    stub_request(:get, "http://twilio_mock_server:4010/v1/CustomerProfiles/BU8f9119bc8f39527dacf01b65b9acb329/ChannelEndpointAssignments?PageSize=20").
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
+
+
+    mock_client = Mock::Twilio::Client.new
+    client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
+    response = client.trusthub.v1.customer_profiles("BU8f9119bc8f39527dacf01b65b9acb329").customer_profiles_channel_endpoint_assignment.list(limit: 20)
+
+    response.each do |assignment|
+      assert assignment.customer_profile_sid.match(%r{BU[0-9a-zA-Z]{32}})
+      assert assignment.sid.match(%r{RA[0-9a-zA-Z]{32}})
+      assert assignment.channel_endpoint_sid.match(%r{PN[0-9a-zA-Z]{32}})
+      assert assignment.url.match(%r{https://trusthub\.twilio\.com/v1/CustomerProfiles/BU[0-9a-zA-Z]{32}/ChannelEndpointAssignments/RA[0-9a-zA-Z]{32}})
+      assert_equal "phone-number", assignment.channel_endpoint_type
+      assert_equal ::Twilio.account_sid, assignment.account_sid
+      assert_equal Time, assignment.date_created.class
+    end
   end
 end

--- a/test/mock/test_mock_end_users.rb
+++ b/test/mock/test_mock_end_users.rb
@@ -14,17 +14,8 @@ class Mock::TestTwilio < Minitest::Test
                              "url"=>"http://example.com"}
 
     stub_request(:post, "http://twilio_mock_server:4010/v1/EndUsers").
-      with(
-        body: {"Attributes"=>"{}", "FriendlyName"=>"friendly_name", "Type"=>"authorized_representative_1"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"Attributes"=>"{}", "FriendlyName"=>"friendly_name", "Type"=>"authorized_representative_1"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
 
     payload = {

--- a/test/mock/test_mock_incoming_phone_numbers.rb
+++ b/test/mock/test_mock_incoming_phone_numbers.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Mock::TestTwilio < Minitest::Test
+  include Mock::Twilio::Generator
+
+  def test_mock_incoming_phone_numbers_update
+    mock_server_response = {
+      "account_sid" => "stringstringstringstringstringstri",
+      "address_sid" => "stringstringstringstringstringstri",
+      "address_requirements" => "string",
+      "api_version" => "string",
+      "beta" => true,
+      "capabilities" => {
+        "mms" => true,
+        "sms" => true,
+        "voice" => true,
+        "fax" => true
+      },
+      "date_created" => "string",
+      "date_updated" => "string",
+      "friendly_name" => "string",
+      "identity_sid" => "stringstringstringstringstringstri",
+      "phone_number" => "string",
+      "origin" => "string",
+      "sid" => "stringstringstringstringstringstri",
+      "sms_application_sid" => "stringstringstringstringstringstri",
+      "sms_fallback_method" => "GET",
+      "sms_fallback_url" => "http://example.com",
+      "sms_method" => "GET",
+      "sms_url" => "http://example.com",
+      "status_callback" => "http://example.com",
+      "status_callback_method" => "GET",
+      "trunk_sid" => "stringstringstringstringstringstri",
+      "uri" => "string",
+      "voice_receive_mode" => "string",
+      "voice_application_sid" => "stringstringstringstringstringstri",
+      "voice_caller_id_lookup" => true,
+      "voice_fallback_method" => "GET",
+      "voice_fallback_url" => "http://example.com",
+      "voice_method" => "GET",
+      "voice_url" => "http://example.com",
+      "emergency_status" => "string",
+      "emergency_address_sid" => "stringstringstringstringstringstri",
+      "emergency_address_status" => "string",
+      "bundle_sid" => "stringstringstringstringstringstri",
+      "status" => "string"
+    }
+
+    app_sid = random_twiml_app_sid
+    phone_number_sid = random_phone_number_sid
+    stub_request(:post, "http://twilio_mock_server:4010/2010-04-01/Accounts/#{::Twilio.account_sid}/IncomingPhoneNumbers/#{phone_number_sid}.json").
+      with(body: {"VoiceApplicationSid" => app_sid, "SmsApplicationSid" => app_sid}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
+
+    mock_client = Mock::Twilio::Client.new
+    client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
+    response = client.incoming_phone_numbers(phone_number_sid).update(sms_application_sid: app_sid, voice_application_sid: app_sid)
+
+    assert_equal Time, response.date_updated.class
+    assert_equal Time, response.date_created.class
+    assert_equal ::Twilio.account_sid, response.account_sid
+    assert response.sid.match(%r{PN[0-9a-zA-Z]{32}})
+    assert response.identity_sid.match(%r{RI[0-9a-zA-Z]{32}})
+    assert response.emergency_address_sid.match(%r{AD[0-9a-zA-Z]{32}})
+    assert response.address_sid.match(%r{AD[0-9a-zA-Z]{32}})
+    assert response.bundle_sid.match(%r{BU[0-9a-zA-Z]{32}})
+  end
+end

--- a/test/mock/test_mock_lookups.rb
+++ b/test/mock/test_mock_lookups.rb
@@ -23,15 +23,7 @@ class Mock::TestTwilio < Minitest::Test
                              "url"=>"http://example.com"}
 
     stub_request(:get, "http://twilio_mock_server:4010/v2/PhoneNumbers/+1123456789?Fields=line_type_intelligence").
-      with(
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
     mock_client = Mock::Twilio::Client.new
     client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)

--- a/test/mock/test_mock_messages.rb
+++ b/test/mock/test_mock_messages.rb
@@ -26,17 +26,8 @@ class Mock::TestTwilio < Minitest::Test
                               "subresource_uris"=>{} }
 
     stub_request(:post, "http://twilio_mock_server:4010/2010-04-01/Accounts/ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/Messages.json").
-      with(
-        body: {"Body"=>"RB This is the ship that made the Kesssssel Run in fourteen parsecs?", "From"=>"+13212855389", "To"=>"+593978613041"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"Body"=>"RB This is the ship that made the Kesssssel Run in fourteen parsecs?", "From"=>"+13212855389", "To"=>"+593978613041"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
     mock_client = Mock::Twilio::Client.new
     client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
@@ -72,17 +63,8 @@ class Mock::TestTwilio < Minitest::Test
                               "subresource_uris"=>{} }
 
     stub_request(:post, "http://twilio_mock_server:4010/2010-04-01/Accounts/ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/Messages.json").
-      with(
-        body: {"Body"=>"RB This is the ship that made the Kesssssel Run in fourteen parsecs?", "From"=>"+13212855389", "MediaUrl"=>"sample", "To"=>"+593978613041"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"Body"=>"RB This is the ship that made the Kesssssel Run in fourteen parsecs?", "From"=>"+13212855389", "MediaUrl"=>"sample", "To"=>"+593978613041"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
     mock_client = Mock::Twilio::Client.new
     client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)

--- a/test/mock/test_mock_messaging_services.rb
+++ b/test/mock/test_mock_messaging_services.rb
@@ -24,15 +24,7 @@ class Mock::TestTwilio < Minitest::Test
                               "key"=>"string"}}
 
     stub_request(:get, "http://twilio_mock_server:4010/v1/Services/MGFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/PhoneNumbers?PageSize=1").
-      with(
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json , headers: {})
+      to_return(status: 200, body: mock_server_response.to_json , headers: {})
 
 
     mock_client = Mock::Twilio::Client.new
@@ -59,17 +51,8 @@ class Mock::TestTwilio < Minitest::Test
                              "url"=>"http://example.com"}
 
     stub_request(:post, "http://twilio_mock_server:4010/v1/Services/MGFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/PhoneNumbers").
-      with(
-        body: {"PhoneNumberSid"=>"PN09b2256564096ff183b0238a545e22f2"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"PhoneNumberSid"=>"PN09b2256564096ff183b0238a545e22f2"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
     mock_client = Mock::Twilio::Client.new
     client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
@@ -97,15 +80,7 @@ class Mock::TestTwilio < Minitest::Test
 
 
     stub_request(:get, "http://twilio_mock_server:4010/v1/Services/MGFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/PhoneNumbers/PN09b2256564096ff183b0238a545e22f2").
-      with(
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
     mock_client = Mock::Twilio::Client.new
     client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)

--- a/test/mock/test_mock_supporting_documents.rb
+++ b/test/mock/test_mock_supporting_documents.rb
@@ -16,17 +16,8 @@ class Mock::TestTwilio < Minitest::Test
                              "url"=>"http://example.com"}
 
     stub_request(:post, "http://twilio_mock_server:4010/v1/SupportingDocuments").
-      with(
-        body: {"Attributes"=>"[]", "FriendlyName"=>"friendly_name", "Type"=>"business"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"Attributes"=>"[]", "FriendlyName"=>"friendly_name", "Type"=>"business"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
     payload = {
       friendly_name: "friendly_name",

--- a/test/mock/test_mock_trust_products.rb
+++ b/test/mock/test_mock_trust_products.rb
@@ -18,17 +18,8 @@ class Mock::TestTwilio < Minitest::Test
                              "links"=>{}}
 
     stub_request(:post, "http://twilio_mock_server:4010/v1/TrustProducts").
-      with(
-        body: {"Email"=>"test", "FriendlyName"=>"test", "PolicySid"=>"RNb0d4771c2c98518d923b3d4cd70a8f8b"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"Email"=>"test", "FriendlyName"=>"test", "PolicySid"=>"RNb0d4771c2c98518d923b3d4cd70a8f8b"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
 
     mock_client = Mock::Twilio::Client.new
@@ -60,17 +51,8 @@ class Mock::TestTwilio < Minitest::Test
                              "links"=>{}}
 
     stub_request(:post, "http://twilio_mock_server:4010/v1/TrustProducts/BU8f9119bc8f39527dacf01b65b9acb329").
-      with(
-        body: {"Status"=>"pending-review"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"Status"=>"pending-review"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
 
     mock_client = Mock::Twilio::Client.new
@@ -95,17 +77,8 @@ class Mock::TestTwilio < Minitest::Test
 
 
     stub_request(:post, "http://twilio_mock_server:4010/v1/TrustProducts/BU8f9119bc8f39527dacf01b65b9acb329/EntityAssignments").
-      with(
-        body: {"ObjectSid"=>"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"ObjectSid"=>"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
     mock_client = Mock::Twilio::Client.new
     client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
@@ -129,17 +102,8 @@ class Mock::TestTwilio < Minitest::Test
                              "url"=>"http://example.com"}
 
     stub_request(:post, "http://twilio_mock_server:4010/v1/TrustProducts/BU9e5209e4eec0b3ff8303a0090ef934aa/Evaluations").
-      with(
-        body: {"PolicySid"=>"RN9e5209e4eec0b3ff8303a0090ef934aa"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 200, body: mock_server_response.to_json, headers: {})
+      with(body: {"PolicySid"=>"RN9e5209e4eec0b3ff8303a0090ef934aa"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
 
     mock_client = Mock::Twilio::Client.new
     client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
@@ -151,5 +115,48 @@ class Mock::TestTwilio < Minitest::Test
     assert_equal "RN", response.policy_sid[0,2]
     assert_equal "BU", response.trust_product_sid[0,2]
     assert_equal "compliant", response.status
+  end
+
+  def test_mock_client_customer_profiles_channel_endpoint_assignments
+    mock_server_response = {
+      "results" => [
+        {
+          "sid" => "stringstringstringstringstringstri",
+          "trust_product_sid" => "stringstringstringstringstringstri",
+          "account_sid" => "stringstringstringstringstringstri",
+          "channel_endpoint_type" => "string",
+          "channel_endpoint_sid" => "stringstringstringstringstringstri",
+          "date_created" => "2019-08-24T14:15:22Z",
+          "url" => "http://example.com"
+        }
+      ],
+      "meta" => {
+        "first_page_url" => "http://example.com",
+        "next_page_url" => "http://example.com",
+        "page" => 0,
+        "page_size" => 0,
+        "previous_page_url" => "http://example.com",
+        "url" => "http://example.com",
+        "key" => "string"
+      }
+    }
+
+    stub_request(:get, "http://twilio_mock_server:4010/v1/TrustProducts/BU8f9119bc8f39527dacf01b65b9acb329/ChannelEndpointAssignments?PageSize=20").
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
+
+
+    mock_client = Mock::Twilio::Client.new
+    client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
+    response = client.trusthub.v1.trust_products("BU8f9119bc8f39527dacf01b65b9acb329").trust_products_channel_endpoint_assignment.list(limit: 20)
+
+    response.each do |assignment|
+      assert assignment.trust_product_sid.match(%r{BU[0-9a-zA-Z]{32}})
+      assert assignment.sid.match(%r{RA[0-9a-zA-Z]{32}})
+      assert assignment.channel_endpoint_sid.match(%r{PN[0-9a-zA-Z]{32}})
+      assert assignment.url.match(%r{https://trusthub\.twilio\.com/v1/TrustProducts/BU[0-9a-zA-Z]{32}/ChannelEndpointAssignments/RA[0-9a-zA-Z]{32}})
+      assert_equal "phone-number", assignment.channel_endpoint_type
+      assert_equal ::Twilio.account_sid, assignment.account_sid
+      assert_equal Time, assignment.date_created.class
+    end
   end
 end

--- a/test/mock/test_mock_webhooks.rb
+++ b/test/mock/test_mock_webhooks.rb
@@ -5,19 +5,8 @@ require "test_helper"
 class Mock::TestTwilio < Minitest::Test
   def test_mock_webhook_message_trigger
     stub_request(:post, "http://shunkan-ido-service:3000/api/v1/twilio_requests/webhook_message_updates").
-      with(
-        body: {"MessageSid"=>"SIDTESTING", "MessageStatus"=>"delivered"},
-        headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'Host'=>'forwarded_host.app',
-          'User-Agent'=>'Faraday v2.9.1',
-          'X-Forwarded-Proto'=>'http',
-          'X-Twilio-Signature'=>'WNqVAu7AugB+SUKrULuBh6cyOKM='
-        }).
-        to_return(status: 200, body: "", headers: {})
+      with(body: {"MessageSid"=>"SIDTESTING", "MessageStatus"=>"delivered"}).
+      to_return(status: 200, body: "", headers: {})
 
     response = Mock::Twilio::Webhooks::Messages.trigger("SIDTESTING")
 
@@ -33,19 +22,8 @@ class Mock::TestTwilio < Minitest::Test
                                   "detail"=>"Invalid Twilio Token, verify the signature"}}
 
     stub_request(:post, "http://shunkan-ido-service:3000/api/v1/twilio_requests/webhook_message_updates").
-      with(
-        body: {"MessageSid"=>"SIDTESTING", "MessageStatus"=>"delivered"},
-        headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'Host'=>'forwarded_host.app',
-          'User-Agent'=>'Faraday v2.9.1',
-          'X-Forwarded-Proto'=>'http',
-          'X-Twilio-Signature'=>'WNqVAu7AugB+SUKrULuBh6cyOKM='
-        }).
-        to_return(status: 500, body: service_response.to_json, headers: { "Content-Type" => "application/json"} )
+      with(body: {"MessageSid"=>"SIDTESTING", "MessageStatus"=>"delivered"}).
+      to_return(status: 500, body: service_response.to_json, headers: { "Content-Type" => "application/json"} )
 
 
     assert_raises(Mock::Twilio::Webhooks::RestError) { Mock::Twilio::Webhooks::Messages.trigger("SIDTESTING") }
@@ -55,19 +33,8 @@ class Mock::TestTwilio < Minitest::Test
     service_response ="<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n </head> \n </body>\n</html>\n"
 
     stub_request(:post, "http://shunkan-ido-service:3000/api/v1/twilio_requests/webhook_message_updates").
-      with(
-        body: {"MessageSid"=>"SIDTESTING", "MessageStatus"=>"delivered"},
-        headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'Host'=>'forwarded_host.app',
-          'User-Agent'=>'Faraday v2.9.1',
-          'X-Forwarded-Proto'=>'http',
-          'X-Twilio-Signature'=>'WNqVAu7AugB+SUKrULuBh6cyOKM='
-        }).
-        to_return(status: 500, body: service_response, headers: { "Content-Type" => "text/html; charset=UTF-8"} )
+      with(body: {"MessageSid"=>"SIDTESTING", "MessageStatus"=>"delivered"}).
+      to_return(status: 500, body: service_response, headers: { "Content-Type" => "text/html; charset=UTF-8"} )
 
 
     assert_raises(Mock::Twilio::Webhooks::RestError) { Mock::Twilio::Webhooks::Messages.trigger("SIDTESTING") }
@@ -75,19 +42,8 @@ class Mock::TestTwilio < Minitest::Test
 
   def test_mock_webhook_calls_trigger
     stub_request(:post, "http://shunkan-ido-service:3000/api/v1/twilio_calls/participant_status_changes").
-      with(
-        body: {"AccountSid"=>"ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "ApiVersion"=>"2010-04-01", "CallDuration"=>"0", "CallSid"=>"SIDTESTING", "CallStatus"=>"ringing", "CallbackSource"=>"call-progress-events", "Called"=>"+18222222222", "CalledCity"=>"TAMPA", "CalledCountry"=>"US", "CalledState"=>"FL", "CalledZip"=>"33605", "Caller"=>"+18111111111", "CallerCity"=>"no value", "CallerCountry"=>"US", "CallerState"=>"CA", "CallerZip"=>"no value", "Direction"=>"outbound-api", "Duration"=>"0", "From"=>"+18111111111", "FromCity"=>"no value", "FromCountry"=>"US", "FromState"=>"CA", "FromZip"=>"no value", "SequenceNumber"=>"2", "SipResponseCode"=>"487", "Timestamp"=>"2024-06-17 16:49:31 UTC", "To"=>"+18222222222", "ToCity"=>"TAMPA", "ToCountry"=>"US", "ToState"=>"FL", "ToZip"=>"33605"},
-        headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'Host'=>'forwarded_host.app',
-          'User-Agent'=>'Faraday v2.9.1',
-          'X-Forwarded-Proto'=>'http',
-          'X-Twilio-Signature'=>'qkaaZdYzQG1Bt9X9dEghrNI/DnY='
-        }).
-        to_return(status: 200, body: "", headers: {})
+      with(body: {"AccountSid"=>"ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "ApiVersion"=>"2010-04-01", "CallDuration"=>"0", "CallSid"=>"SIDTESTING", "CallStatus"=>"ringing", "CallbackSource"=>"call-progress-events", "Called"=>"+18222222222", "CalledCity"=>"TAMPA", "CalledCountry"=>"US", "CalledState"=>"FL", "CalledZip"=>"33605", "Caller"=>"+18111111111", "CallerCity"=>"no value", "CallerCountry"=>"US", "CallerState"=>"CA", "CallerZip"=>"no value", "Direction"=>"outbound-api", "Duration"=>"0", "From"=>"+18111111111", "FromCity"=>"no value", "FromCountry"=>"US", "FromState"=>"CA", "FromZip"=>"no value", "SequenceNumber"=>"2", "SipResponseCode"=>"487", "Timestamp"=>"2024-06-17 16:49:31 UTC", "To"=>"+18222222222", "ToCity"=>"TAMPA", "ToCountry"=>"US", "ToState"=>"FL", "ToZip"=>"33605"}).
+      to_return(status: 200, body: "", headers: {})
 
     response = Mock::Twilio::Webhooks::Calls.trigger("SIDTESTING", "ringing")
 
@@ -99,19 +55,8 @@ class Mock::TestTwilio < Minitest::Test
 
   def test_mock_webhook_calls_updates_trigger
     stub_request(:post, "http://shunkan-ido-service:3000/api/v1/twilio_calls/voice_responses").
-      with(
-        body: {"AccountSid"=>"ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "AnsweredBy"=>"unknown", "ApiVersion"=>"2010-04-01", "CallDuration"=>"0", "CallSid"=>"SIDTESTING", "CallStatus"=>"ringing", "CallbackSource"=>"call-progress-events", "Called"=>"+18222222222", "CalledCity"=>"TAMPA", "CalledCountry"=>"US", "CalledState"=>"FL", "CalledZip"=>"33605", "Caller"=>"+18111111111", "CallerCity"=>"no value", "CallerCountry"=>"US", "CallerState"=>"CA", "CallerZip"=>"no value", "Direction"=>"outbound-api", "Duration"=>"0", "From"=>"+18111111111", "FromCity"=>"no value", "FromCountry"=>"US", "FromState"=>"CA", "FromZip"=>"no value", "SequenceNumber"=>"2", "SipResponseCode"=>"487", "StirStatus"=>"B", "StirVerstat"=>"TN-Validation-Passed-B", "Timestamp"=>"2024-06-17 16:49:31 UTC", "To"=>"+18222222222", "ToCity"=>"TAMPA", "ToCountry"=>"US", "ToState"=>"FL", "ToZip"=>"33605", "conference_uuid"=>"123abc"},
-        headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'Host'=>'forwarded_host.app',
-          'User-Agent'=>'Faraday v2.9.1',
-          'X-Forwarded-Proto'=>'http',
-          'X-Twilio-Signature'=>'op1IQVORDwLhrX7ft0WASFiLT8U='
-        }).
-        to_return(status: 200, body: "", headers: {})
+      with(body: {"AccountSid"=>"ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "AnsweredBy"=>"unknown", "ApiVersion"=>"2010-04-01", "CallDuration"=>"0", "CallSid"=>"SIDTESTING", "CallStatus"=>"ringing", "CallbackSource"=>"call-progress-events", "Called"=>"+18222222222", "CalledCity"=>"TAMPA", "CalledCountry"=>"US", "CalledState"=>"FL", "CalledZip"=>"33605", "Caller"=>"+18111111111", "CallerCity"=>"no value", "CallerCountry"=>"US", "CallerState"=>"CA", "CallerZip"=>"no value", "Direction"=>"outbound-api", "Duration"=>"0", "From"=>"+18111111111", "FromCity"=>"no value", "FromCountry"=>"US", "FromState"=>"CA", "FromZip"=>"no value", "SequenceNumber"=>"2", "SipResponseCode"=>"487", "StirStatus"=>"B", "StirVerstat"=>"TN-Validation-Passed-B", "Timestamp"=>"2024-06-17 16:49:31 UTC", "To"=>"+18222222222", "ToCity"=>"TAMPA", "ToCountry"=>"US", "ToState"=>"FL", "ToZip"=>"33605", "conference_uuid"=>"123abc"}).
+      to_return(status: 200, body: "", headers: {})
 
 
     response = Mock::Twilio::Webhooks::CallStatusUpdates.trigger("SIDTESTING","123abc", "unknown", "ringing")
@@ -123,19 +68,8 @@ class Mock::TestTwilio < Minitest::Test
 
   def test_mock_webhook_customer_profile_trigger
     stub_request(:post, "http://shunkan-ido-service:3000/webhooks/twilio/customer_profiles_compliance").
-      with(
-        body: {"BundleSid"=>"SIDTESTING", "Status"=>"in-review"},
-        headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'Host'=>'forwarded_host.app',
-          'User-Agent'=>'Faraday v2.9.1',
-          'X-Forwarded-Proto'=>'http',
-          'X-Twilio-Signature'=>'3/Xbee9zCe2IfVU8N6olgb3VBXg='
-        }).
-        to_return(status: 200, body: "", headers: {})
+      with(body: {"BundleSid"=>"SIDTESTING", "Status"=>"in-review"}).
+      to_return(status: 200, body: "", headers: {})
 
     response = Mock::Twilio::Webhooks::CustomerProfiles.trigger("SIDTESTING", "in-review")
 
@@ -146,19 +80,8 @@ class Mock::TestTwilio < Minitest::Test
 
   def test_mock_webhook_message_inbound_trigger
     stub_request(:post, "http://shunkan-ido-service:3000/api/v1/twilio_requests/inbound").
-      with(
-        body: {"AccountSid"=>"ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "AddOns"=>"{\"status\":\"successful\",\"message\":null,\"code\":null,\"results\":{}}", "ApiVersion"=>"2010-04-01", "Body"=>"Inbound::Message mock reply", "From"=>"+1987654321", "FromCity"=>"SILVERDALE", "FromCountry"=>"US", "FromState"=>"WA", "FromZip"=>"98315", "MessageSid"=>"SIDTESTING", "MessagingServiceSid"=>"MFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFff", "NumMedia"=>"0", "NumSegments"=>"1", "SmsMessageSid"=>"SIDTESTING", "SmsSid"=>"SIDTESTING", "SmsStatus"=>"received", "To"=>"+1123456789", "ToCity"=>"SARDIS", "ToCountry"=>"US", "ToState"=>"MS", "ToZip"=>"38666"},
-        headers: {
-          'Accept'=>'*/*',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QUNGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRjpTS1hYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'Host'=>'forwarded_host.app',
-          'User-Agent'=>'Faraday v2.9.1',
-          'X-Forwarded-Proto'=>'http',
-          'X-Twilio-Signature'=>'Ivv/g+EGMwuhN8+3PpwlsS+A1eg='
-        }).
-        to_return(status: 200, body: "", headers: {})
+      with(body: {"AccountSid"=>"ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "AddOns"=>"{\"status\":\"successful\",\"message\":null,\"code\":null,\"results\":{}}", "ApiVersion"=>"2010-04-01", "Body"=>"Inbound::Message mock reply", "From"=>"+1987654321", "FromCity"=>"SILVERDALE", "FromCountry"=>"US", "FromState"=>"WA", "FromZip"=>"98315", "MessageSid"=>"SIDTESTING", "MessagingServiceSid"=>"MFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFff", "NumMedia"=>"0", "NumSegments"=>"1", "SmsMessageSid"=>"SIDTESTING", "SmsSid"=>"SIDTESTING", "SmsStatus"=>"received", "To"=>"+1123456789", "ToCity"=>"SARDIS", "ToCountry"=>"US", "ToState"=>"MS", "ToZip"=>"38666"}).
+      to_return(status: 200, body: "", headers: {})
 
     request = Struct.new(:To, :From, :MessagingServiceSid)
     request_data = request.new(To: "+1123456789", From: "+1987654321", MessagingServiceSid: "MFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFff")

--- a/test/mock/test_twilio.rb
+++ b/test/mock/test_twilio.rb
@@ -24,17 +24,8 @@ class Mock::TestTwilio < Minitest::Test
                              "validation"=>[{"location"=>["path", "accountsid"], "severity"=>"Error", "code"=>"minLength", "message"=>"Request path parameter accountsid must NOT have fewer than 34 characters"}, {"location"=>["path", "accountsid"], "severity"=>"Error", "code"=>"pattern", "message"=>"Request path parameter accountsid must match pattern \"^AC[0-9a-fA-F]{32}$\""}]}
 
     stub_request(:post, "http://twilio_mock_server:4010/2010-04-01/Accounts/BADTOKEN/Messages.json").
-      with(
-        body: {"Body"=>"RB This is the ship that made the Kesssssel Run in fourteen parsecs?", "From"=>"+13212855389", "To"=>"+593978613041"},
-        headers: {
-          'Accept'=>'application/json',
-          'Accept-Charset'=>'utf-8',
-          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Authorization'=>'Basic QkFEVE9LRU46U0tYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWA==',
-          'Content-Type'=>'application/x-www-form-urlencoded',
-          'User-Agent'=>'twilio-ruby/7.1.0 (linux x86_64) Ruby/3.2.2'
-        }).
-        to_return(status: 422, body: mock_server_response.to_json, headers: {})
+      with(body: {"Body"=>"RB This is the ship that made the Kesssssel Run in fourteen parsecs?", "From"=>"+13212855389", "To"=>"+593978613041"}).
+      to_return(status: 422, body: mock_server_response.to_json, headers: {})
 
     mock_client = Mock::Twilio::Client.new
     client = ::Twilio::REST::Client.new('BADTOKEN', nil, nil, nil, mock_client)


### PR DESCRIPTION
…and updating incoming phone numbers

https://ss-group.atlassian.net/browse/COMM-838

Adds support for:
- `client.incoming_phone_numbers.update(sms_application_sid: "AP"+"F"*32, voice_application_sid: "AP"+"F"*32)`
- `client.trusthub.v1.customer_profiles("BU"+"F"*32).customer_profiles_channel_endpoint_assignment.list(limit: 20)`
- `client.trusthub.v1.customer_profiles("BU"+"F"*32).customer_profiles_channel_endpoint_assignment("RA"+"F"*32).delete`
- `client.trusthub.v1.trust_products("BU"+"F"*32).trust_products_channel_endpoint_assignment.list(limit: 20)`
- `client.trusthub.v1.trust_products("BU"+"F"*32).trust_products_channel_endpoint_assignment("RA"+"F"*32).delete`

Fixes tests to work on Mac and Linux.