### PR TITLE
chore: Add 429 preferer response CreateMessage

### DIFF
--- a/lib/mock/twilio/middleware/proxy.rb
+++ b/lib/mock/twilio/middleware/proxy.rb
@@ -14,7 +14,15 @@ module Mock
           env.url.host = env.request.proxy.host
           env.url.port = env.request.proxy.port
           env.url.scheme = env.request.proxy.scheme
+          env.request_headers.merge!({ 'Prefer' => 'code=429' }) if forced_error(env.request_body)
           super
+        end
+
+        def forced_error(request_body)
+          return unless request_body && request_body["Body"]
+
+          string = ::Rack::Utils.parse_nested_query(request_body)
+          string["Body"].downcase.include?('error')
         end
       end
     end

--- a/mock-twilio.gemspec
+++ b/mock-twilio.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rufus-scheduler", ">= 3.9.1"
   spec.add_dependency "twilio-ruby", ">= 7.0.0"
   spec.add_dependency "activesupport", ">= 6.0.0"
+  spec.add_dependency "rack", ">= 3.1.8"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/test/mock/test_twilio.rb
+++ b/test/mock/test_twilio.rb
@@ -32,4 +32,17 @@ class Mock::TestTwilio < Minitest::Test
 
     assert_raises(Twilio::REST::RestError) { client.messages.create(to: "+593978613041", body: "RB This is the ship that made the Kesssssel Run in fourteen parsecs?", from: "+13212855389") }
   end
+
+  def test_mock_client_custom_error
+    mock_server_response = { "error" => "Too many request"  }
+
+    stub_request(:post, "http://twilio_mock_server:4010/2010-04-01/Accounts/ACFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/Messages.json").
+      with(body: {"Body"=>"Create Message with error", "From"=>"+13212855389", "To"=>"+593978613041"}).
+      to_return(status: 429, body: mock_server_response.to_json, headers: {})
+
+    mock_client = Mock::Twilio::Client.new
+    client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
+
+    assert_raises(Twilio::REST::RestError) { client.messages.create(to: "+593978613041", body: "Create Message with error", from: "+13212855389") }
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ require "twilio-ruby"
 
 require "minitest/autorun"
 require 'webmock/minitest'
+require "rack"
 require "pry"
 
 Twilio.configure do |config|


### PR DESCRIPTION
## Add forced_error
```ruby
HTTP/1.1 429 Too Many Requests
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: *
Access-Control-Allow-Credentials: true
Access-Control-Expose-Headers: *
Content-type: application/json
Content-Length: 28
Date: Thu, 07 Nov 2024 16:29:49 GMT
Connection: keep-alive
Keep-Alive: timeout=5

{
   "error" : "Too many request"
}
```
-o-
```ruby
Twilio::REST::RestError: [HTTP 429] 429 : Unable to create record


from /usr/local/bundle/ruby/3.3.0/gems/twilio-ruby-7.3.3/lib/twilio-ruby/framework/rest/version.rb:146:in `create'

```
## Requirements

- twilio_mock_server prism 429 response