### PR TITLE
chore: add line_type_intelligence mobile and landline

### DIFF
--- a/lib/mock/twilio/schemas/phone_numbers_v2.rb
+++ b/lib/mock/twilio/schemas/phone_numbers_v2.rb
@@ -10,9 +10,18 @@ module Mock
             body["country_code"] = 'US' if body["country_code"]
             body["valid"] = true if body["valid"]
             body["validation_errors"] = [] if body["validation_errors"]
-            body["line_type_intelligence"] = { "carrier_name" => "Mock::Twilio - SMS/MMS-SVR", "type" => "mock" }
+            body["line_type_intelligence"] = { "carrier_name" => "Mock::Twilio - SMS/MMS-SVR", "type" => line_type(request) }
 
             body
+          end
+
+          private
+
+          def line_type(request)
+            # https://www.twilio.com/docs/lookup/v2-api/line-type-intelligence#type-property-values
+            return "landline" if request.url[-1] == "9"
+
+            "mobile"
           end
         end
       end

--- a/test/mock/test_mock_lookups.rb
+++ b/test/mock/test_mock_lookups.rb
@@ -3,7 +3,37 @@
 require "test_helper"
 
 class Mock::TestTwilio < Minitest::Test
-  def test_mock_client_lookups_v2
+  def test_mock_client_lookups_v2_mobile
+    mock_server_response = { "calling_country_code"=>"1",
+                             "country_code"=>"US",
+                             "phone_number"=>"string",
+                             "national_format"=>"string",
+                             "valid"=>true,
+                             "validation_errors"=>[],
+                             "caller_name"=>nil,
+                             "sim_swap"=>nil,
+                             "call_forwarding"=>nil,
+                             "line_status"=>nil,
+                             "line_type_intelligence"=>nil,
+                             "identity_match"=>nil,
+                             "reassigned_number"=>nil,
+                             "sms_pumping_risk"=>nil,
+                             "phone_number_quality_score"=>nil,
+                             "pre_fill"=>nil,
+                             "url"=>"http://example.com"}
+
+    stub_request(:get, "http://twilio_mock_server:4010/v2/PhoneNumbers/+1123456788?Fields=line_type_intelligence").
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
+
+    mock_client = Mock::Twilio::Client.new
+    client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
+    response = client.lookups.v2.phone_numbers("+1123456788") .fetch(fields: :line_type_intelligence)
+
+    assert_equal "mobile", response.line_type_intelligence["type"]
+    assert response.valid
+  end
+
+  def test_mock_client_lookups_v2_landline
     mock_server_response = { "calling_country_code"=>"1",
                              "country_code"=>"US",
                              "phone_number"=>"string",
@@ -29,7 +59,7 @@ class Mock::TestTwilio < Minitest::Test
     client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
     response = client.lookups.v2.phone_numbers("+1123456789") .fetch(fields: :line_type_intelligence)
 
-    assert_equal "mock", response.line_type_intelligence["type"]
+    assert_equal "landline", response.line_type_intelligence["type"]
     assert response.valid
   end
 end


### PR DESCRIPTION
## line_type_intelligence
- mobile (except numbers ending with 9)
- landline (only numbers ending with 9)