### PR TITLE
feat: Add callback_url fordwarding support

### DIFF
--- a/lib/mock/twilio/decorators/api_2010/messages.rb
+++ b/lib/mock/twilio/decorators/api_2010/messages.rb
@@ -35,9 +35,10 @@ module Mock
               prefix = request.data["MediaUrl"] ? "MM" : "SM"
               sid = prefix + SecureRandom.hex(16)
               scheduler = Rufus::Scheduler.new
+              callback_url = request.data["StatusCallback"] if request.data["StatusCallback"]
               scheduler.in '2s' do
                 begin
-                  response = Mock::Twilio::Webhooks::Messages.trigger(sid)
+                  response = Mock::Twilio::Webhooks::Messages.trigger(sid, callback_url)
 
                   if response.success? && request.data["Body"].downcase.include?("inbound")
                     inbound_sid = prefix + SecureRandom.hex(16)

--- a/lib/mock/twilio/webhooks/base.rb
+++ b/lib/mock/twilio/webhooks/base.rb
@@ -26,10 +26,9 @@ module Mock
         end
 
         def self.headers
-          {
-            'X-Forwarded-Proto': Mock::Twilio.proto,
-            'Host': Mock::Twilio.forwarded_host
-          }
+          return { 'Host': Mock::Twilio.forwarded_host }.merge!({ 'X-Forwarded-Proto': Mock::Twilio.proto }) if Mock::Twilio.proto == "http"
+
+          { 'Host': Mock::Twilio.forwarded_host }
         end
       end
     end

--- a/lib/mock/twilio/webhooks/messages.rb
+++ b/lib/mock/twilio/webhooks/messages.rb
@@ -4,13 +4,12 @@ module Mock
   module Twilio
     module Webhooks
       class Messages < Base
-        URL = "/api/v1/twilio_requests/webhook_message_updates"
-
-        def self.trigger(sid)
+        def self.trigger(sid, callback_url)
           # Wait simulation from twilio
           sleep DELAY.sample
 
-          request_url = Mock::Twilio.proto + "://" + Mock::Twilio.forwarded_host + URL
+          request_url = callback_url
+          url = callback_url.split(Mock::Twilio.host).last
 
           data = { :MessageSid=>sid, :MessageStatus=>"delivered" }
 
@@ -19,7 +18,7 @@ module Mock
           response = webhook_client.request(Mock::Twilio.host,
                                             Mock::Twilio.port,
                                             'POST',
-                                            URL,
+                                            url,
                                             nil,
                                             data,
                                             headers.merge!({ 'X-Twilio-Signature': signature }),


### PR DESCRIPTION
## Add callback_url fordwarding support

The URL of the endpoint to which Twilio sends [Message status callback requests](https://www.twilio.com/docs/sms/api/message-resource#twilios-request-to-the-statuscallback-url). URL must contain a valid hostname and underscores are not allowed.


https://www.twilio.com/docs/messaging/api/message-resource#request-body-parameters

```ruby
client.messages.create(to: "+123123123", body: "Test sample", from: "+12312312323", status_callback: "https://test.com/callback")
```