### PR TITLE
feat: add availablephonenumberslocal support (COMM-950)

### DIFF
--- a/lib/mock/twilio/decorators/api_2010/available_phone_numbers_local.rb
+++ b/lib/mock/twilio/decorators/api_2010/available_phone_numbers_local.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Mock
+  module Twilio
+    module Decorators
+      module Api2010
+        class AvailablePhoneNumbersLocal
+          class << self
+            include Mock::Twilio::Generator
+
+            PAGES_KEYS = [
+              "end",
+              "first_page_uri",
+              "next_page_uri",
+              "last_page_uri",
+              "page",
+              "page_size",
+              "previous_page_uri",
+              "total",
+              "num_pages",
+              "start",
+              "uri"
+            ].freeze
+
+            def decorate(body, request)
+              PAGES_KEYS.each do |key|
+                body.delete(key) if body.key?(key)
+              end
+
+              body["available_phone_numbers"].each do |number|
+                number["address_requirements"] = "none"
+                number["friendly_name"] = friendly_number_generator
+                number["iso_country"] = "US"
+                number["lata"] = rand(100..999).to_s
+                number["latitude"] = random_latitude.to_s
+                number["longitude"] = random_longitude.to_s
+                number["locality"] = "Hilo"
+                number["postal_code"] = rand(10000..99999).to_s
+                number["rate_center"] = "HILO"
+                number["region"] = "HI"
+                number["phone_number"] = phone_number_generator
+              end
+
+              body["uri"] = "/2010-04-01/Accounts/#{::Twilio.account_sid}/AvailablePhoneNumbers/US/Local.json"
+
+              body
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mock/twilio/schemas/api_2010.rb
+++ b/lib/mock/twilio/schemas/api_2010.rb
@@ -52,8 +52,10 @@ module Mock
             when %r{\/2010-04-01/Accounts/[A-Za-z0-9]+/Addresses.json}
               RESOURCES[:addresses].decorate(body, request)
             when %r{\/2010-04-01/Accounts/[A-Za-z0-9]+/IncomingPhoneNumbers/[A-Za-z0-9]+.json}
+              # Update
               RESOURCES[:incoming_phone_numbers].decorate(body, request)
             when %r{\/2010-04-01/Accounts/[A-Za-z0-9]+/IncomingPhoneNumbers.json}
+              # Create
               RESOURCES[:incoming_phone_numbers].decorate(body, request)
             when %r{\/2010-04-01/Accounts/[A-Za-z0-9]+/AvailablePhoneNumbers/[A-Z]+/Local.json}
               RESOURCES[:available_phone_numbers_local].decorate(body, request)

--- a/lib/mock/twilio/schemas/api_2010.rb
+++ b/lib/mock/twilio/schemas/api_2010.rb
@@ -6,6 +6,7 @@ require_relative "../decorators/api_2010/conferences_participants_update"
 require_relative "../decorators/api_2010/conferences_participants_create"
 require_relative "../decorators/api_2010/addresses"
 require_relative "../decorators/api_2010/incoming_phone_numbers"
+require_relative "../decorators/api_2010/available_phone_numbers_local"
 
 module Mock
   module Twilio
@@ -19,6 +20,7 @@ module Mock
             conferences_participants_create: Mock::Twilio::Decorators::Api2010::ConferencesParticipantsCreate,
             addresses: Mock::Twilio::Decorators::Api2010::Addresses,
             incoming_phone_numbers: Mock::Twilio::Decorators::Api2010::IncomingPhoneNumbers,
+            available_phone_numbers_local: Mock::Twilio::Decorators::Api2010::AvailablePhoneNumbersLocal
           }
 
           PAGES_KEYS = [
@@ -51,6 +53,10 @@ module Mock
               RESOURCES[:addresses].decorate(body, request)
             when %r{\/2010-04-01/Accounts/[A-Za-z0-9]+/IncomingPhoneNumbers/[A-Za-z0-9]+.json}
               RESOURCES[:incoming_phone_numbers].decorate(body, request)
+            when %r{\/2010-04-01/Accounts/[A-Za-z0-9]+/IncomingPhoneNumbers.json}
+              RESOURCES[:incoming_phone_numbers].decorate(body, request)
+            when %r{\/2010-04-01/Accounts/[A-Za-z0-9]+/AvailablePhoneNumbers/[A-Z]+/Local.json}
+              RESOURCES[:available_phone_numbers_local].decorate(body, request)
             end
           end
         end

--- a/lib/mock/twilio/util/generator.rb
+++ b/lib/mock/twilio/util/generator.rb
@@ -4,7 +4,11 @@ module Mock
   module Twilio
     module Generator
       def phone_number_generator
-        "+1" + rand(100000000..999999999).to_s
+        "+1" + rand(1000000000..9999999999).to_s
+      end
+
+      def friendly_number_generator
+        "(#{rand(100..999)}) #{rand(100..999)}-#{rand(1000..9999)}"
       end
 
       def random_phone_number_sid
@@ -35,7 +39,20 @@ module Mock
         random_sid_prefixed_by "RA"
       end
 
+      def random_longitude
+        rand(MIN_LONGITUDE..MAX_LONGITUDE)
+      end
+
+      def random_latitude
+        rand(MIN_LATITUDE..MAX_LATITUDE)
+      end
+
       private
+
+      MIN_LATITUDE = -90.0
+      MAX_LATITUDE = 90.0
+      MIN_LONGITUDE = -180.0
+      MAX_LONGITUDE = 180.0
 
       def random_sid_prefixed_by(prefix)
         "#{prefix}#{SecureRandom.hex(16)}"

--- a/test/mock/test_mock_available_phone_numbers_local.rb
+++ b/test/mock/test_mock_available_phone_numbers_local.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Mock::TestTwilio < Minitest::Test
+  include Mock::Twilio::Generator
+
+  def test_mock_available_phone_numbers_local_list
+    mock_server_response = {
+      "available_phone_numbers" => [
+        {
+          "friendly_name" => "string",
+          "phone_number" => "string",
+          "lata" => "string",
+          "locality" => "string",
+          "rate_center" => "string",
+          "latitude" => 0,
+          "longitude" => 0,
+          "region" => "string",
+          "postal_code" => "string",
+          "iso_country" => "string",
+          "address_requirements" => "string",
+          "beta" => true,
+          "capabilities" => {
+            "mms" => true,
+            "sms" => true,
+            "voice" => true,
+            "fax" => true
+          }
+        }
+      ],
+      "end" => 0,
+      "first_page_uri" => "http://example.com",
+      "next_page_uri" => "http://example.com",
+      "page" => 0,
+      "page_size" => 0,
+      "previous_page_uri" => "http://example.com",
+      "start" => 0,
+      "uri" => "http://example.com"
+    }
+
+    stub_request(:get, "http://twilio_mock_server:4010/2010-04-01/Accounts/#{Twilio.account_sid}/AvailablePhoneNumbers/US/Local.json?MmsEnabled=true&PageSize=1&SmsEnabled=true").
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
+
+    mock_client = Mock::Twilio::Client.new
+    client = ::Twilio::REST::Client.new(Twilio.account_sid, SecureRandom.hex(16), nil, nil, mock_client)
+    response = client.available_phone_numbers("US").local.list(limit: 1, sms_enabled: true, mms_enabled: true)
+
+    response.each do |number|
+      assert_equal number.address_requirements, "none"
+      assert number.friendly_name.match(/\([0-9]{3}\) [0-9]{3}-[0-9]{4}/)
+      assert_equal number.iso_country, "US"
+      assert number.lata.match(%r{[0-9]{3}})
+      assert number.latitude.match(%r{^[-+]?[0-9]*\.?[0-9]+$})
+      assert number.longitude.match(%r{^[-+]?[0-9]*\.?[0-9]+$})
+      assert_equal number.locality, "Hilo"
+      assert number.postal_code.match(%r{[0-9]{5}})
+      assert_equal number.rate_center, "HILO"
+      assert_equal number.region, "HI"
+      assert number.phone_number.match(/\+1[0-9]{10}/)
+    end
+  end
+end

--- a/test/mock/test_mock_incoming_phone_numbers.rb
+++ b/test/mock/test_mock_incoming_phone_numbers.rb
@@ -67,4 +67,67 @@ class Mock::TestTwilio < Minitest::Test
     assert response.address_sid.match(%r{AD[0-9a-zA-Z]{32}})
     assert response.bundle_sid.match(%r{BU[0-9a-zA-Z]{32}})
   end
+
+  def test_mock_incoming_phone_numbers_create
+    mock_server_response = {
+      "account_sid" => "stringstringstringstringstringstri",
+      "address_sid" => "stringstringstringstringstringstri",
+      "address_requirements" => "string",
+      "api_version" => "string",
+      "beta" => true,
+      "capabilities" => {
+        "mms" => true,
+        "sms" => true,
+        "voice" => true,
+        "fax" => true
+      },
+      "date_created" => "string",
+      "date_updated" => "string",
+      "friendly_name" => "string",
+      "identity_sid" => "stringstringstringstringstringstri",
+      "phone_number" => "string",
+      "origin" => "string",
+      "sid" => "stringstringstringstringstringstri",
+      "sms_application_sid" => "stringstringstringstringstringstri",
+      "sms_fallback_method" => "GET",
+      "sms_fallback_url" => "http://example.com",
+      "sms_method" => "GET",
+      "sms_url" => "http://example.com",
+      "status_callback" => "http://example.com",
+      "status_callback_method" => "GET",
+      "trunk_sid" => "stringstringstringstringstringstri",
+      "uri" => "string",
+      "voice_receive_mode" => "string",
+      "voice_application_sid" => "stringstringstringstringstringstri",
+      "voice_caller_id_lookup" => true,
+      "voice_fallback_method" => "GET",
+      "voice_fallback_url" => "http://example.com",
+      "voice_method" => "GET",
+      "voice_url" => "http://example.com",
+      "emergency_status" => "string",
+      "emergency_address_sid" => "stringstringstringstringstringstri",
+      "emergency_address_status" => "string",
+      "bundle_sid" => "stringstringstringstringstringstri",
+      "status" => "string"
+    }
+
+    app_sid = random_twiml_app_sid
+    phone_number_sid = random_phone_number_sid
+    stub_request(:post, "http://twilio_mock_server:4010/2010-04-01/Accounts/#{::Twilio.account_sid}/IncomingPhoneNumbers.json").
+      with(body: {"PhoneNumber" => "+14155552344"}).
+      to_return(status: 200, body: mock_server_response.to_json, headers: {})
+
+    mock_client = Mock::Twilio::Client.new
+    client = ::Twilio::REST::Client.new(nil, nil, nil, nil, mock_client)
+    response = client.incoming_phone_numbers.create(phone_number: '+14155552344')
+
+    assert_equal Time, response.date_updated.class
+    assert_equal Time, response.date_created.class
+    assert_equal ::Twilio.account_sid, response.account_sid
+    assert response.sid.match(%r{PN[0-9a-zA-Z]{32}})
+    assert response.identity_sid.match(%r{RI[0-9a-zA-Z]{32}})
+    assert response.emergency_address_sid.match(%r{AD[0-9a-zA-Z]{32}})
+    assert response.address_sid.match(%r{AD[0-9a-zA-Z]{32}})
+    assert response.bundle_sid.match(%r{BU[0-9a-zA-Z]{32}})
+  end
 end

--- a/test/mock/test_mock_messaging_services.rb
+++ b/test/mock/test_mock_messaging_services.rb
@@ -64,7 +64,7 @@ class Mock::TestTwilio < Minitest::Test
     assert_equal "PN", response.sid[0,2]
     assert_equal "AC", response.account_sid[0,2]
     assert_equal "MG", response.service_sid[0,2]
-    assert_equal 11, response.phone_number.length
+    assert_equal 12, response.phone_number.length
   end
 
   def test_mock_client_messaging_services_phone_numbers_fetch
@@ -92,6 +92,6 @@ class Mock::TestTwilio < Minitest::Test
     assert_equal "PN", response.sid[0,2]
     assert_equal "AC", response.account_sid[0,2]
     assert_equal "MG", response.service_sid[0,2]
-    assert_equal 11, response.phone_number.length
+    assert_equal 12, response.phone_number.length
   end
 end


### PR DESCRIPTION
https://ss-group.atlassian.net/browse/COMM-950

Adds a decorator for the `AvailablePhoneNumbersLocal` Twilio endpoint.