### PR TITLE
chore: add support to custom webhook messages update url

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,30 @@ OR
 ## How to use
 Initializer sample
 ```ruby
+# Local Docker/Host
 Mock::Twilio.configure do |config|
-  config.host = "http://shunkan-ido-service"
-  config.forwarded_host = "shunkan-ido-service"
+  config.host = "http://shunkan-ido-service:3000"
+  config.forwarded_host = "shunkan-ido-service:3000"
   config.port = "3000"
   config.proto = "http"
-  # optional
-  # webhook_message_status_url has preference over status_callback
-  # webhook_message_status_url supports twilio signature validation
-  # config.webhook_message_status_url = "http://shunkan_ido/api/v1/twilio_requests/webhook_message_updates"
+  # optional https://www.twilio.com/docs/messaging/api/message-resource#request-body-parameters
+  # Use webhook_message_status_url as the Integration Send webhook from Messaging Service.
+  # If you include status_callback parameter with the messaging_service_sid,
+  # Twilio uses status_callback URL instead of the Status Callback URL(webhook_message_status_url) of the Messaging Service.
+  # config.webhook_message_status_url = "http://shunkan_ido:3000/api/v1/twilio_requests/webhook_message_updates"
+end
+
+# Real http(s) url
+Mock::Twilio.configure do |config|
+  config.host = "https://my-server"
+  config.forwarded_host = "my-server"
+  config.port = "443"
+  config.proto = "https"
+  # optional https://www.twilio.com/docs/messaging/api/message-resource#request-body-parameters
+  # Use webhook_message_status_url as the Integration Send webhook from Messaging Service.
+  # If you include status_callback parameter with the messaging_service_sid,
+  # Twilio uses status_callback URL instead of the Status Callback URL(webhook_message_status_url) of the Messaging Service.
+  # config.webhook_message_status_url = "https://my-server/api/v1/twilio_requests/webhook_message_updates"
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Mock::Twilio.configure do |config|
   config.forwarded_host = "shunkan-ido-service"
   config.port = "3000"
   config.proto = "http"
+  # optional
+  # webhook_message_status_url has preference over status_callback
+  # webhook_message_status_url supports twilio signature validation
+  # config.webhook_message_status_url = "http://shunkan_ido/api/v1/twilio_requests/webhook_message_updates"
 end
 ```
 

--- a/lib/mock/twilio.rb
+++ b/lib/mock/twilio.rb
@@ -28,7 +28,7 @@ module Mock
   module Twilio
     extend SingleForwardable
 
-    def_delegators :configuration, :host, :forwarded_host, :port, :proto
+    def_delegators :configuration, :host, :forwarded_host, :port, :proto, :webhook_message_status_url
 
     def self.configure(&block)
       yield configuration

--- a/lib/mock/twilio/util/configuration.rb
+++ b/lib/mock/twilio/util/configuration.rb
@@ -4,7 +4,7 @@ module Mock
   module Twilio
     module Util
       class Configuration
-        attr_accessor :host, :forwarded_host, :port, :proto
+        attr_accessor :host, :forwarded_host, :port, :proto, :webhook_message_status_url
 
         def host=(value)
           @host = value
@@ -20,6 +20,10 @@ module Mock
 
         def proto=(value)
           @proto = value
+        end
+
+        def webhook_message_status_url=(value)
+          @webhook_message_status_url = value
         end
       end
     end

--- a/lib/mock/twilio/webhook_client.rb
+++ b/lib/mock/twilio/webhook_client.rb
@@ -12,7 +12,9 @@ module Mock
       end
 
       def _request(request)
-        @connection = Faraday.new(url: request.host + ":" + request.port.to_s, ssl: { verify: true }) do |f|
+        url = request.host.split(":").last.to_i.zero? ? (request.host + ":" + request.port.to_s) : request.host
+
+        @connection = Faraday.new(url: url, ssl: { verify: true }) do |f|
           f.options.params_encoder = Faraday::FlatParamsEncoder
           f.request :url_encoded
           f.adapter @adapter

--- a/lib/mock/twilio/webhooks/base.rb
+++ b/lib/mock/twilio/webhooks/base.rb
@@ -26,7 +26,7 @@ module Mock
         end
 
         def self.headers
-          return { 'Host': Mock::Twilio.forwarded_host }.merge!({ 'X-Forwarded-Proto': Mock::Twilio.proto }) if Mock::Twilio.proto == "http"
+          return { 'Host': Mock::Twilio.forwarded_host, 'X-Forwarded-Proto': Mock::Twilio.proto } if Mock::Twilio.proto == "http"
 
           { 'Host': Mock::Twilio.forwarded_host }
         end

--- a/lib/mock/twilio/webhooks/messages.rb
+++ b/lib/mock/twilio/webhooks/messages.rb
@@ -8,8 +8,15 @@ module Mock
           # Wait simulation from twilio
           sleep DELAY.sample
 
-          request_url = callback_url
-          url = callback_url.split(Mock::Twilio.host).last
+          if Mock::Twilio.webhook_message_status_url
+            request_url = Mock::Twilio.webhook_message_status_url
+            url = Mock::Twilio.webhook_message_status_url.split(Mock::Twilio.host).last
+          elsif callback_url
+            request_url = callback_url
+            url = callback_url.split(Mock::Twilio.host).last
+          else
+            raise "There is not webhook_message_status_url or status_callback"
+          end
 
           data = { :MessageSid=>sid, :MessageStatus=>"delivered" }
 

--- a/lib/mock/twilio/webhooks/messages.rb
+++ b/lib/mock/twilio/webhooks/messages.rb
@@ -8,12 +8,12 @@ module Mock
           # Wait simulation from twilio
           sleep DELAY.sample
 
-          if Mock::Twilio.webhook_message_status_url
-            request_url = Mock::Twilio.webhook_message_status_url
-            url = Mock::Twilio.webhook_message_status_url.split(Mock::Twilio.host).last
-          elsif callback_url
+          if callback_url
             request_url = callback_url
             url = callback_url.split(Mock::Twilio.host).last
+          elsif Mock::Twilio.webhook_message_status_url
+            request_url = Mock::Twilio.webhook_message_status_url
+            url = Mock::Twilio.webhook_message_status_url.split(Mock::Twilio.host).last
           else
             raise "There is not webhook_message_status_url or status_callback"
           end

--- a/test/mock/test_mock_webhooks.rb
+++ b/test/mock/test_mock_webhooks.rb
@@ -94,4 +94,29 @@ class Mock::TestTwilio < Minitest::Test
     assert_equal "Ivv/g+EGMwuhN8+3PpwlsS+A1eg=", response.env.request_headers['X-twilio-signature']
     assert_equal expected_body, response.env.request_body
   end
+
+  def test_mock_webhook_message_status_url_trigger
+    Mock::Twilio.configure do |config|
+      config.webhook_message_status_url = "http://shunkan_ido/api/v1/twilio_requests/webhook_message_updates"
+    end
+
+    stub_request(:post, "http://shunkan_ido/api/v1/twilio_requests/webhook_message_updates").
+      with(body: {"MessageSid"=>"SIDTESTING", "MessageStatus"=>"delivered"}).
+      to_return(status: 200, body: "", headers: {})
+
+    response = Mock::Twilio::Webhooks::Messages.trigger("SIDTESTING", "http://test.com/callback_url")
+
+    assert_equal "forwarded_host.app", response.env.request_headers['Host']
+    assert_equal "http", response.env.request_headers['X-forwarded-proto']
+    assert_equal "fSX0swfxH1zw3AxBsY8hFGSlQR4=", response.env.request_headers['X-twilio-signature']
+    assert_equal "MessageSid=SIDTESTING&MessageStatus=delivered", response.env.request_body
+
+    Mock::Twilio.configure do |config|
+      config.webhook_message_status_url = nil
+    end
+  end
+
+  def test_mock_webhook_message_urls_trigger_error
+    assert_raises("There is not webhook_message_status_url or status_callback") { Mock::Twilio::Webhooks::Messages.trigger("SIDTESTING", nil) }
+  end
 end

--- a/test/mock/test_mock_webhooks.rb
+++ b/test/mock/test_mock_webhooks.rb
@@ -104,7 +104,7 @@ class Mock::TestTwilio < Minitest::Test
       with(body: {"MessageSid"=>"SIDTESTING", "MessageStatus"=>"delivered"}).
       to_return(status: 200, body: "", headers: {})
 
-    response = Mock::Twilio::Webhooks::Messages.trigger("SIDTESTING", "http://test.com/callback_url")
+    response = Mock::Twilio::Webhooks::Messages.trigger("SIDTESTING", nil)
 
     assert_equal "forwarded_host.app", response.env.request_headers['Host']
     assert_equal "http", response.env.request_headers['X-forwarded-proto']


### PR DESCRIPTION
### Support webhook_client host with and without port
```ruby
# Local Docker/Host
config.host = "http://shunkan-ido-service:3000"
  
OR
  
# Real http(s) url
config.host = "https://my-server"
```
  
### Support custom  webhook message update url
```ruby
# Local Docker/Host
Mock::Twilio.configure do |config|
  config.host = "http://shunkan-ido-service:3000"
  config.forwarded_host = "shunkan-ido-service:3000"
  config.port = "3000"
  config.proto = "http"
  # optional https://www.twilio.com/docs/messaging/api/message-resource#request-body-parameters
  # Use webhook_message_status_url as the Integration Send webhook from Messaging Service.
  # If you include status_callback parameter with the messaging_service_sid,
  # Twilio uses status_callback URL instead of the Status Callback URL(webhook_message_status_url) of the Messaging Service.
  config.webhook_message_status_url = "http://shunkan_ido:3000/api/v1/twilio_requests/webhook_message_updates"
end

# Real http(s) url
Mock::Twilio.configure do |config|
  config.host = "https://my-server"
  config.forwarded_host = "my-server"
  config.port = "443"
  config.proto = "https"
  # optional https://www.twilio.com/docs/messaging/api/message-resource#request-body-parameters
  # Use webhook_message_status_url as the Integration Send webhook from Messaging Service.
  # If you include status_callback parameter with the messaging_service_sid,
  # Twilio uses status_callback URL instead of the Status Callback URL(webhook_message_status_url) of the Messaging Service.
  config.webhook_message_status_url = "https://my-server/api/v1/twilio_requests/webhook_message_updates"
end
```