### PR TITLE
Relax faraday dependency to >= 2.0, < 3

### DIFF
--- a/mock-twilio.gemspec
+++ b/mock-twilio.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "faraday", "<= 2.8.0"
+  spec.add_dependency "faraday", ">= 2.0", "< 3"
   spec.add_dependency "rufus-scheduler", ">= 3.9.1"
   spec.add_dependency "twilio-ruby", ">= 7.0.0"
   spec.add_dependency "activesupport", ">= 6.0.0"


### PR DESCRIPTION
## Summary

- Relaxes the faraday dependency from `<= 2.8.0` to `>= 2.0, < 3`
- The gem only uses stable Faraday APIs (`Faraday.new`, `Faraday::Middleware`, `Faraday::FlatParamsEncoder`) that haven't changed across 2.x versions
- The previous constraint prevented projects from using newer faraday releases (e.g. 2.14.x) that include security fixes

## Test plan

- [x] All existing tests pass with faraday 2.14.1 (41 runs, 159 assertions, 0 failures, 0 errors)